### PR TITLE
changed test commands to cl/dl instead of cll/dll

### DIFF
--- a/lists/python/README.python.md
+++ b/lists/python/README.python.md
@@ -17,10 +17,10 @@ _NOTE: using `-x` is recommended so you can follow a flow similar to test driven
 
 You can filter out specific tests i.e. just the DoublyLinkedList tests using the `-k` flag.
 ```bash
-pytest -x -k test_dll lists/
+pytest -x -k test_dl lists/
 ```
 
 You can use the following filters to run tests for the specific type of lists
   - LinkedList: `-k test_ll`
-  - DoubleLinkedList: `-k test_dll`
-  - CircularlyLinkedList: `-k test_cll`
+  - DoubleLinkedList: `-k test_dl`
+  - CircularlyLinkedList: `-k test_cl`


### PR DESCRIPTION
Pytest commands for double list and circular lists were listed as dll/cll, but weren't working. Should be dl/cl based on test_linked_list.py test structure. I updated the readme.